### PR TITLE
Feature Tables, DB Port, new Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 A Python library for interacting with a Chado database.
 
+## Scripts
+
+This library additionally ships with a number of useful command line scripts:
+
+Script               | Description
+-------------------- | ------------
+`create_analysis.py` | Create a new analysis
+`create_organism.py` | Create a new organism
+`dbshell.py`         | Invoke a database shell session
+`export_fa.py`       | Export any sequence records associated with an organism
+`export_gbk.py`      | Export a GenBank formatted dataset for an organism
+`export_gff3.py`     | Export a GFF3 formatted dataset for an organism
+`list_organisms.py`  | List organisms in the database
+`purge_organism.py`  | Remove an organism from the database
+
+(This list was generated with `egrep "argparse.*description='(.*)'" -R scripts -o | sed "s/'$//g;s/:.*'/ | /g;"`)
+
+### Optional Dependency: Progress
+
+If the library `tqdm` is installed, a progress bar will be displayed for the
+scripts which export data from the database.
+
 ## License
 
 Available under the MIT License

--- a/chado/__init__.py
+++ b/chado/__init__.py
@@ -22,6 +22,15 @@ class Db(object):
 class Cv(object):
     pass
 
+class Feature(object):
+    pass
+
+class FeatureLocation(object):
+    pass
+
+class FeatureProperties(object):
+    pass
+
 def ChadoAuth(parser):
     parser.add_argument('-o', '--dbhost', required=True, help='Database Host')
     parser.add_argument('-n', '--dbname', required=True, help='Database Name')
@@ -78,6 +87,12 @@ class ChadoInstance(object):
         mapper(Db, db)
         cv = Table('cv', self._metadata, autoload=True)
         mapper(Cv, cv)
+        feature = Table('feature',    self._metadata, autoload=True)
+        mapper(Feature, feature)
+        featureloc = Table('featureloc', self._metadata, autoload=True)
+        mapper(FeatureLocation, featureloc)
+        featureprop = Table('featureprop', self._metadata, autoload=True)
+        mapper(FeatureProperties, featureprop)
 
     def get_cvterm_id(self, type_name, cv_name):
         res = self.session.query(Cvterm, Cv).filter(Cvterm.name == type_name, Cv.name == cv_name)

--- a/chado/__init__.py
+++ b/chado/__init__.py
@@ -31,6 +31,9 @@ class FeatureLocation(object):
 class FeatureProperties(object):
     pass
 
+class FeatureRelationship(object):
+    pass
+
 def ChadoAuth(parser):
     parser.add_argument('-o', '--dbhost', required=True, help='Database Host')
     parser.add_argument('-n', '--dbname', required=True, help='Database Name')
@@ -96,6 +99,8 @@ class ChadoInstance(object):
         mapper(FeatureLocation, featureloc)
         featureprop = Table('featureprop', self._metadata, autoload=True)
         mapper(FeatureProperties, featureprop)
+        feature_relationship = Table('feature_relationship', self._metadata, autoload=True)
+        mapper(FeatureRelationship, feature_relationship)
 
     def get_cvterm_id(self, type_name, cv_name):
         res = self.session.query(Cvterm, Cv).filter(Cvterm.name == type_name, Cv.name == cv_name)

--- a/chado/__init__.py
+++ b/chado/__init__.py
@@ -35,17 +35,19 @@ def ChadoAuth(parser):
     parser.add_argument('-o', '--dbhost', required=True, help='Database Host')
     parser.add_argument('-n', '--dbname', required=True, help='Database Name')
     parser.add_argument('-u', '--dbuser', help='Database Username')
-    parser.add_argument('-p', '--dbpass', help='Database Password')
+    parser.add_argument('-w', '--dbpass', help='Database Password')
+    parser.add_argument('-p', '--dbport', type=int, help='Database Port', default=5432)
     parser.add_argument('--dbschema', help='Database Schema (default: public)', default="public")
     parser.add_argument("-d", "--debug", help="Print debug information", action="store_true")
 
 class ChadoInstance(object):
 
-    def __init__(self, dbhost, dbname, dbuser, dbpass, dbschema, debug):
+    def __init__(self, dbhost, dbname, dbuser, dbpass, dbschema, dbport, debug, **kwargs):
         self.dbhost = dbhost
         self.dbname = dbname
         self.dbuser = dbuser
         self.dbpass = dbpass
+        self.dbport = dbport
         self.dbschema = dbschema
 
         self.debug = debug
@@ -55,7 +57,7 @@ class ChadoInstance(object):
 
     def connect(self):
 
-        self._engine = create_engine('postgresql://%s:%s@%s/%s' % (self.dbuser, self.dbpass, self.dbhost, self.dbname), echo=self.debug)
+        self._engine = create_engine('postgresql://%s:%s@%s:%s/%s' % (self.dbuser, self.dbpass, self.dbhost, self.dbport, self.dbname), echo=self.debug)
         self._metadata = MetaData(self._engine, schema=self.dbschema)
 
         Session = sessionmaker(bind=self._engine)

--- a/chado/__init__.py
+++ b/chado/__init__.py
@@ -98,7 +98,7 @@ class ChadoInstance(object):
     def get_cvterm_id(self, type_name, cv_name):
         res = self.session.query(Cvterm, Cv).filter(Cvterm.name == type_name, Cv.name == cv_name)
         if not res.count():
-            raise Exception("Could not find a cvterm with name '%s' from cv ''%s' in the database %s" % (type_name, cv_name, ci._engine.url))
+            raise Exception("Could not find a cvterm with name '%s' from cv ''%s' in the database %s" % (type_name, cv_name, self._engine.url))
 
         return res.one().Cvterm.cvterm_id
 

--- a/chado/__init__.py
+++ b/chado/__init__.py
@@ -103,6 +103,13 @@ class ChadoInstance(object):
         return res.one().Cvterm.cvterm_id
 
     def get_cvterm_name(self, cv_id):
+        """
+        get_cvterm_name allows lookup of CV terms by their ID.
+
+        This method caches the result in order to not hit the DB for every
+        query. Maybe should investigate pre-loading popular terms? (E.g. gene,
+        mRNA, etc)
+        """
         if cv_id in self._cv_id_cache:
             if self._cv_id_cache[cv_id] is not None:
                 return self._cv_id_cache[cv_id]

--- a/scripts/create_analysis.py
+++ b/scripts/create_analysis.py
@@ -19,7 +19,7 @@ if __name__ == '__main__':
     ChadoAuth(parser)
     args = parser.parse_args()
 
-    ci = ChadoInstance(args.dbhost, args.dbname, args.dbuser, args.dbpass, args.dbschema, args.debug)
+    ci = ChadoInstance(**vars(args))
 
     ci.connect()
 

--- a/scripts/create_organism.py
+++ b/scripts/create_organism.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
     ChadoAuth(parser)
     args = parser.parse_args()
 
-    ci = ChadoInstance(args.dbhost, args.dbname, args.dbuser, args.dbpass, args.dbschema, args.debug)
+    ci = ChadoInstance(**vars(args))
 
     ci.connect()
 

--- a/scripts/dbshell.py
+++ b/scripts/dbshell.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import os
+import subprocess
+import argparse
+from chado import ChadoAuth
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Create a new organism')
+
+    ChadoAuth(parser)
+    args = parser.parse_args()
+    subprocess.call(
+        [
+            'psql',
+            '-h', args.dbhost,
+            '-U', args.dbuser,
+            '-p', str(args.dbport),
+            args.dbname
+        ],
+        env=dict(os.environ, PGPASSWORD=args.dbpass)
+    )

--- a/scripts/dbshell.py
+++ b/scripts/dbshell.py
@@ -5,7 +5,7 @@ import argparse
 from chado import ChadoAuth
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Create a new organism')
+    parser = argparse.ArgumentParser(description='Invoke a database shell session')
 
     ChadoAuth(parser)
     args = parser.parse_args()

--- a/scripts/export_fa.py
+++ b/scripts/export_fa.py
@@ -41,11 +41,20 @@ if __name__ == '__main__':
         else:
             output = sys.stdout
 
+        if HAS_PROGRESS_BAR:
+            sbar = tqdm.tqdm(total=sequence_features.count(), desc='sequences')
+
         for seq in sequence_features:
             output.write('>{0.uniquename} [ID={0.feature_id}]'.format(seq))
             output.write('\n')
             output.write(seq.residues)
             output.write('\n')
+
+            if HAS_PROGRESS_BAR:
+                sbar.update(1)
+
+        if HAS_PROGRESS_BAR:
+            sbar.close()
 
         if args.file:
             output.close()

--- a/scripts/export_fa.py
+++ b/scripts/export_fa.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+import argparse
+import sys
+from Bio import SeqIO
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
+from Bio.Alphabet import IUPAC
+from Bio.SeqFeature import SeqFeature
+from Bio.SeqFeature import FeatureLocation as BioFeatureLocation
+
+
+from chado import ChadoAuth, ChadoInstance, Organism, Feature, FeatureLocation, FeatureProperties
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Create a new organism')
+
+    parser.add_argument("orgId", nargs='+', help="The id of the organism")
+    parser.add_argument("--file", action='store_true', help="Store sequences in files split by organism")
+    ChadoAuth(parser)
+    args = parser.parse_args()
+
+    ci = ChadoInstance(**vars(args))
+    ci.connect()
+
+    # check if the organism exists
+    res = ci.session.query(Organism) \
+        .filter(Organism.organism_id.in_(args.orgId))
+
+    for org in res:
+        sequence_features = ci.session.query(Feature) \
+            .filter_by(organism_id=org.organism_id) \
+            .filter(Feature.seqlen > 0)
+
+        if args.file:
+            output = open('{0.organism_id}.{0.genus}.{0.species}-{0.common_name}.fa'.format(org), 'w')
+        else:
+            output = sys.stdout
+
+        for seq in sequence_features:
+            output.write('>{0.uniquename} [ID={0.feature_id}]'.format(seq))
+            output.write('\n')
+            output.write(seq.residues)
+            output.write('\n')
+
+        if args.file:
+            output.close()

--- a/scripts/export_fa.py
+++ b/scripts/export_fa.py
@@ -12,7 +12,7 @@ from Bio.SeqFeature import FeatureLocation as BioFeatureLocation
 from chado import ChadoAuth, ChadoInstance, Organism, Feature, FeatureLocation, FeatureProperties
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Create a new organism')
+    parser = argparse.ArgumentParser(description='Export any sequence records associated with an organism')
 
     parser.add_argument("orgId", nargs='+', help="The id of the organism")
     parser.add_argument("--file", action='store_true', help="Store sequences in files split by organism")

--- a/scripts/export_gbk.py
+++ b/scripts/export_gbk.py
@@ -43,10 +43,14 @@ if __name__ == '__main__':
         record_features = []
         features = ci.session.query(Feature, FeatureLocation) \
             .filter_by(organism_id=org.organism_id) \
-            .join(FeatureLocation, Feature.feature_id == FeatureLocation.feature_id, isouter=True) \
-            .all()
+            .join(FeatureLocation, Feature.feature_id == FeatureLocation.feature_id, isouter=True)
+
+        if HAS_PROGRESS_BAR:
+            fbar = tqdm.tqdm(total=features.count(), desc='features')
 
         for feature, featureloc  in features:
+            if HAS_PROGRESS_BAR:
+                fbar.update(1)
             # Sequence containing feature
             if feature.residues:
                 # This seems bad? What if multiple things have seqs?
@@ -65,6 +69,9 @@ if __name__ == '__main__':
                         qualifiers=qualifiers
                     )
                 )
+
+        if HAS_PROGRESS_BAR:
+            fbar.close()
 
         record = SeqRecord(
             seq, id=org.common_name,

--- a/scripts/export_gbk.py
+++ b/scripts/export_gbk.py
@@ -12,7 +12,7 @@ from Bio.SeqFeature import FeatureLocation as BioFeatureLocation
 from chado import ChadoAuth, ChadoInstance, Organism, Feature, FeatureLocation, FeatureProperties
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Create a new organism')
+    parser = argparse.ArgumentParser(description='Export a GenBank formatted dataset for an organism')
 
     parser.add_argument("orgId", nargs='+', help="The id of the organism")
     ChadoAuth(parser)

--- a/scripts/export_gbk.py
+++ b/scripts/export_gbk.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
     ChadoAuth(parser)
     args = parser.parse_args()
 
-    ci = ChadoInstance(args.dbhost, args.dbname, args.dbuser, args.dbpass, args.dbschema, args.debug)
+    ci = ChadoInstance(**vars(args))
     ci.connect()
 
     # check if the organism exists

--- a/scripts/export_gbk.py
+++ b/scripts/export_gbk.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+import sys
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
@@ -59,5 +60,4 @@ if __name__ == '__main__':
         )
         record.features = record_features
 
-        with open('out.gb', 'w') as handle:
-            SeqIO.write([record], handle, 'genbank')
+        SeqIO.write([record], sys.stdout, 'genbank')

--- a/scripts/export_gbk.py
+++ b/scripts/export_gbk.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+import argparse
+from Bio import SeqIO
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
+from Bio.Alphabet import IUPAC
+from Bio.SeqFeature import SeqFeature
+from Bio.SeqFeature import FeatureLocation as BioFeatureLocation
+
+
+from chado import ChadoAuth, ChadoInstance, Organism, Feature, FeatureLocation, FeatureProperties
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Create a new organism')
+
+    parser.add_argument("orgId", nargs='+', help="The id of the organism")
+    ChadoAuth(parser)
+    args = parser.parse_args()
+
+    ci = ChadoInstance(args.dbhost, args.dbname, args.dbuser, args.dbpass, args.dbschema, args.debug)
+    ci.connect()
+
+    # check if the organism exists
+    res = ci.session.query(Organism).filter(Organism.organism_id.in_(args.orgId))
+
+    for org in res:
+        seq = None
+
+        record_features = []
+        features = ci.session.query(Feature, FeatureLocation) \
+            .filter_by(organism_id=org.organism_id) \
+            .join(FeatureLocation, Feature.feature_id == FeatureLocation.feature_id, isouter=True) \
+            .all()
+
+        for feature, featureloc  in features:
+            # Sequence containing feature
+            if feature.residues:
+                # This seems bad? What if multiple things have seqs?
+                seq = Seq(feature.residues, IUPAC.unambiguous_dna)
+            else:
+                qualifiers = {
+                    ci.get_cvterm_name(prop.type_id): prop.value for prop in
+                    ci.session.query(FeatureProperties).filter_by(feature_id=feature.feature_id).all()
+                }
+                record_features.append(
+                    SeqFeature(
+                        BioFeatureLocation(featureloc.fmin, featureloc.fmax),
+                        id=feature.uniquename,
+                        type=ci.get_cvterm_name(feature.type_id),
+                        strand=featureloc.strand,
+                        qualifiers=qualifiers
+                    )
+                )
+
+        record = SeqRecord(
+            seq, id=org.common_name,
+            name=org.common_name,
+            description="%s %s" % (org.genus, org.species),
+        )
+        record.features = record_features
+
+        with open('out.gb', 'w') as handle:
+            SeqIO.write([record], handle, 'genbank')

--- a/scripts/export_gff3.py
+++ b/scripts/export_gff3.py
@@ -15,7 +15,7 @@ log = logging.getLogger(name='export_gff3')
 from chado import ChadoAuth, ChadoInstance, Organism, Feature, FeatureLocation, FeatureProperties, FeatureRelationship
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Create a new organism')
+    parser = argparse.ArgumentParser(description='Export a GFF3 formatted dataset for an organism')
 
     parser.add_argument("orgId", nargs='+', help="The id of the organism")
     ChadoAuth(parser)

--- a/scripts/export_gff3.py
+++ b/scripts/export_gff3.py
@@ -8,7 +8,7 @@ from Bio.Alphabet import IUPAC
 from Bio.SeqFeature import SeqFeature
 from Bio.SeqFeature import FeatureLocation as BioFeatureLocation
 import logging
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig()
 log = logging.getLogger(name='export_gff3')
 
 
@@ -90,7 +90,6 @@ if __name__ == '__main__':
         # https://github.com/biopython/biopython/issues/928
         for rel in relationships:
             term = ci.get_cvterm_name(rel.type_id)
-            log.debug("rel (%s %s %s)", rel.subject_id, term, rel.object_id)
             if term != 'part_of':
                 log.error("Cannot handle non-part_of relationships (%s %s %s)", rel.subject_id, term, rel.object_id)
                 continue
@@ -103,7 +102,6 @@ if __name__ == '__main__':
             assert len(parent) <= 1
             alreadyProcessedParent = False
             alreadyProcessedChild = False
-            log.debug('%s %s %s %s', alreadyProcessedChild, len(child), alreadyProcessedParent, len(parent))
 
             # If they aren't there, pull them from the complete set.
             if len(child) == 0:

--- a/scripts/export_gff3.py
+++ b/scripts/export_gff3.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+import argparse
+from BCBio import GFF
+import sys
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
+from Bio.Alphabet import IUPAC
+from Bio.SeqFeature import SeqFeature
+from Bio.SeqFeature import FeatureLocation as BioFeatureLocation
+import logging
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger(name='export_gff3')
+
+
+from chado import ChadoAuth, ChadoInstance, Organism, Feature, FeatureLocation, FeatureProperties, FeatureRelationship
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Create a new organism')
+
+    parser.add_argument("orgId", nargs='+', help="The id of the organism")
+    ChadoAuth(parser)
+    args = parser.parse_args()
+
+    ci = ChadoInstance(**vars(args))
+    ci.connect()
+
+    # check if the organism exists
+    res = ci.session.query(Organism).filter(Organism.organism_id.in_(args.orgId))
+
+    for org in res:
+        # TODO: can we do this properly?
+        seq = Seq("A" * 1, IUPAC.unambiguous_dna)
+
+        record_features = []
+        # Annotation features
+        features = ci.session.query(Feature, FeatureLocation) \
+            .filter_by(organism_id=org.organism_id) \
+            .filter(Feature.seqlen==None) \
+            .join(FeatureLocation, Feature.feature_id == FeatureLocation.feature_id, isouter=True) \
+            .all()
+
+        biopy_features = {}
+        for feature, featureloc  in features:
+            #[u'dbxref_id', u'feature_id', u'is_analysis', u'is_obsolete',
+            # u'md5checksum', u'name', u'organism_id', u'residues', u'seqlen',
+            # u'timeaccessioned', u'timelastmodified', u'type_id',
+            # u'uniquename']
+            #[u'feature_id', u'featureloc_id', u'fmax', u'fmin',
+            # u'is_fmax_partial', u'is_fmin_partial', u'locgroup', u'phase',
+            # u'rank', u'residue_info', u'srcfeature_id', u'strand']
+            qualifiers = {
+                ci.get_cvterm_name(prop.type_id): prop.value for prop in
+                ci.session.query(FeatureProperties).filter_by(feature_id=feature.feature_id).all()
+            }
+
+            qualifiers['ID'] = feature.uniquename
+
+            biopy_features[feature.feature_id] = SeqFeature(
+                BioFeatureLocation(featureloc.fmin, featureloc.fmax),
+                id=feature.uniquename,
+                type=ci.get_cvterm_name(feature.type_id),
+                strand=featureloc.strand,
+                qualifiers=qualifiers
+            )
+
+    #res = ci.session.query(Organism).filter(Organism.organism_id.in_(args.orgId))
+        relationships = ci.session.query(FeatureRelationship) \
+            .filter(FeatureRelationship.subject_id.in_(biopy_features.keys()))
+
+ #feature_relationship_id | subject_id | object_id | type_id | value | rank
+#-------------------------+------------+-----------+---------+-------+------
+                       #1 |          4 |         3 |      37 |       |    0
+                       #2 |          5 |         4 |      37 |       |    0
+                       #3 |          6 |         4 |      37 |       |    0
+                       #4 |          7 |         4 |      37 |       |    0
+
+        features = []
+
+        def findById(feature_list, id):
+            for feature in feature_list:
+                if feature.id == id:
+                    yield feature
+
+                if hasattr(feature, 'sub_features'):
+                    for x in findById(feature.sub_features, id):
+                        yield x
+
+        # Now to re-parent things properly
+        # This is BioPython 1.67 ONLY since they broke compatability with bcbio-gff
+        # https://github.com/biopython/biopython/issues/928
+        for rel in relationships:
+            term = ci.get_cvterm_name(rel.type_id)
+            log.debug("rel (%s %s %s)", rel.subject_id, term, rel.object_id)
+            if term != 'part_of':
+                log.error("Cannot handle non-part_of relationships (%s %s %s)", rel.subject_id, term, rel.object_id)
+                continue
+
+            # Try and find the features in features.
+            child = list(findById(features, biopy_features[rel.subject_id].id))
+            parent = list(findById(features, biopy_features[rel.object_id].id))
+
+            assert len(child) <= 1
+            assert len(parent) <= 1
+            alreadyProcessedParent = False
+            alreadyProcessedChild = False
+            log.debug('%s %s %s %s', alreadyProcessedChild, len(child), alreadyProcessedParent, len(parent))
+
+            # If they aren't there, pull them from the complete set.
+            if len(child) == 0:
+                child = biopy_features[rel.subject_id]
+            else:
+                child = child[0]
+                alreadyProcessedChild = True
+
+            if len(parent) == 0:
+                parent = biopy_features[rel.object_id]
+            else:
+                parent = parent[0]
+                alreadyProcessedParent = True
+
+            if not hasattr(parent, 'sub_features'):
+                parent.sub_features = []
+
+            parent.sub_features.append(child)
+            if alreadyProcessedChild and alreadyProcessedParent:
+                # Here we've seen both (they're BOTH in the list), so we need to remove
+                # child and not touch parent since we added to parent already
+                features.remove(child)
+            elif alreadyProcessedChild and not alreadyProcessedParent:
+                # Here our child is already in features, so we need to remove it from
+                # the feature set, add to the parent (done) and re-place in features.
+                features.remove(child)
+                features.append(parent)
+            elif not alreadyProcessedChild and alreadyProcessedParent:
+                # In this case we've seen the parent before, already in list, no need to do anything
+                # features.append(parent)
+                pass
+            else:
+                # Otherwise, completely new feature.
+                features.append(parent)
+
+        record = SeqRecord(
+            seq,
+            id=org.common_name,
+            name=org.common_name,
+            description="%s %s" % (org.genus, org.species),
+        )
+        record.features = sorted(features, key=lambda f: f.location.start)
+
+        GFF.write([record], sys.stdout)

--- a/scripts/list_organisms.py
+++ b/scripts/list_organisms.py
@@ -3,7 +3,7 @@ import argparse
 from chado import ChadoAuth, ChadoInstance, Organism
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Create a new organism')
+    parser = argparse.ArgumentParser(description='List organisms in the database')
 
     parser.add_argument("--genus", help="The genus of the organism")
     parser.add_argument("--species", help="The species of the organism")

--- a/scripts/list_organisms.py
+++ b/scripts/list_organisms.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+import argparse
+from chado import ChadoAuth, ChadoInstance, Organism
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Create a new organism')
+
+    parser.add_argument("--genus", help="The genus of the organism")
+    parser.add_argument("--species", help="The species of the organism")
+    parser.add_argument("--common", help="The common name of the organism")
+    parser.add_argument("--abbr", help="The abbreviation of the organism")
+    parser.add_argument("--comment", help="The comment of the organism")
+    parser.add_argument("-q", "--quiet", action='store_true', help="Only print out IDs")
+
+    ChadoAuth(parser)
+    args = parser.parse_args()
+
+    ci = ChadoInstance(**vars(args))
+
+    ci.connect()
+
+    # check if the organism exists
+    res = ci.session.query(Organism)
+    if args.genus:
+        res = res.filter_by(genus=args.genus)
+    if args.species:
+        res = res.filter_by(species=args.species)
+    if args.common:
+        res = res.filter_by(common_name=args.common)
+    if args.abbr:
+        res = res.filter_by(abbreviation=args.abbr)
+    if args.comment:
+        res = res.filter_by(comment=args.comment)
+
+    for org in res:
+        if args.quiet:
+            print org.organism_id
+        else:
+            print '\t'.join(map(str, (
+                org.organism_id,
+                org.genus,
+                org.species,
+                org.abbreviation,
+                org.common_name,
+                org.comment,
+            )))

--- a/scripts/purge_organism.py
+++ b/scripts/purge_organism.py
@@ -4,7 +4,7 @@ import argparse
 from chado import ChadoAuth, ChadoInstance, Organism
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Create a new organism')
+    parser = argparse.ArgumentParser(description='Remove an organism from the database')
 
     ChadoAuth(parser)
     args = parser.parse_args()

--- a/scripts/purge_organism.py
+++ b/scripts/purge_organism.py
@@ -9,7 +9,7 @@ if __name__ == '__main__':
     ChadoAuth(parser)
     args = parser.parse_args()
 
-    ci = ChadoInstance(args.dbhost, args.dbname, args.dbuser, args.dbpass, args.dbschema, args.debug)
+    ci = ChadoInstance(**vars(args))
 
     ci.connect()
 


### PR DESCRIPTION
Features:
- new tables: feature/featureloc/featureprop/feature_relationship
- CV term lookup by name with cache
- export genbank, gff3, fasta from chado
- stupid/simple scripts to list organisms, open a dbshell (I was fond of `python manage.py dbshell` in django)
- optional progress bar dependency for long export steps (`tqdm`, was quite easy to use. https://pypi.python.org/pypi/tqdm)

Additionally:
- dbport was added to the ChadoAuth, and defaults to 5432.
- `**vars(args)` is used instead of manually specifying all the parameters, this means that the entire argparse parameter set is passed to the auth call
- On the auth call side, `**kwargs` is used and completely ignored, while we take all the named parameters.

API Changes
- Password is now `-w` and port is `-p`, more similar to the `psql` flags.
