### PR TITLE
Fix broken --skip_missing option for load_go

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ $ chakin feature load_fasta \
 
 ## History
 
+- 2.2.4
+    - Fix broken --skip_missing option for load_go
+
 - 2.2.3
     - Throw a warning instead of an exception when a GFF target feature does not exist
 

--- a/chado/feature/__init__.py
+++ b/chado/feature/__init__.py
@@ -1364,7 +1364,11 @@ class FeatureClient(Client):
                     else:
                         raise Exception('Could not find feature with name "%s"' % feat_id)
 
-                term_id = self.ci.get_cvterm_id(term_acc, term_db)
+                try:
+                    term_id = self.ci.get_cvterm_id(term_acc, term_db)
+                except chado.RecordNotFoundError:
+                    term_id = None
+
                 if not term_id:
                     if skip_missing:
                         print('Could not find term with name "%s", skipping it' % term_acc)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="chado",
-    version='2.2.3',
+    version='2.2.4',
     description="Chado library",
     author="Anthony Bretaudeau",
     author_email="anthony.bretaudeau@inra.fr",


### PR DESCRIPTION
A little fix for a bug found while loading real data (with a chado db containing old GO data)