### PR TITLE
Decode feature_id when searching in cache.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ $ chakin feature load_fasta \
 
 ## History
 
+- 2.3.9
+    - URL decode GFF ids when loading blast/interpro/others
+
 - 2.3.8
     - Fix connection closed error when loading big interproscan files
 

--- a/chado/client.py
+++ b/chado/client.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import re
+from urllib.parse import unquote
 
 from chado.exceptions import RecordNotFoundError
 
@@ -116,15 +117,22 @@ class Client(object):
             re_res = re.search(re_name, feature_id)
             if re_res:
                 feature_id = re_res.group(1)
+            else:
+                re_res = re.search(re_name, unquote(feature_id))
+                if re_res:
+                    feature_id = re_res.group(1)
 
         cache_id = (feature_id, organism_id, seqterm)
 
         if cache_id not in self._feature_cache:
-            if skip_missing:
-                warn('Could not find feature with name "%s", skipping it', feature_id)
-                return None
-            else:
-                raise RecordNotFoundError('Could not find feature with name "%s"' % feature_id)
+            # Check after decoding
+            cache_id = (unquote(feature_id), organism_id, seqterm)
+            if cache_id not in self._feature_cache:
+                if skip_missing:
+                    warn('Could not find feature with name "%s", skipping it', feature_id)
+                    return None
+                else:
+                    raise RecordNotFoundError('Could not find feature with name "%s"' % feature_id)
 
         return self._feature_cache[cache_id]['feature_id']
 

--- a/chado/client.py
+++ b/chado/client.py
@@ -133,11 +133,6 @@ class Client(object):
                     return None
                 else:
                     raise RecordNotFoundError('Could not find feature with name "%s"' % feature_id)
-            if skip_missing:
-                warn('Could not find feature with name "%s", skipping it', feature_id)
-                return None
-            else:
-                raise RecordNotFoundError('Could not find feature with name "%s"' % feature_id)
 
         return self._feature_cache[cache_id]['feature_id']
 

--- a/chado/client.py
+++ b/chado/client.py
@@ -112,27 +112,21 @@ class Client(object):
     def _match_feature(self, feature_id, re_name, query_type, organism_id, skip_missing=False):
 
         seqterm = self.ci.get_cvterm_id(query_type, 'sequence')
+        feature_id = unquote(feature_id)
 
         if re_name:
             re_res = re.search(re_name, feature_id)
             if re_res:
                 feature_id = re_res.group(1)
-            else:
-                re_res = re.search(re_name, unquote(feature_id))
-                if re_res:
-                    feature_id = re_res.group(1)
 
         cache_id = (feature_id, organism_id, seqterm)
 
         if cache_id not in self._feature_cache:
-            # Check after decoding
-            cache_id = (unquote(feature_id), organism_id, seqterm)
-            if cache_id not in self._feature_cache:
-                if skip_missing:
-                    warn('Could not find feature with name "%s", skipping it', feature_id)
-                    return None
-                else:
-                    raise RecordNotFoundError('Could not find feature with name "%s"' % feature_id)
+            if skip_missing:
+                warn('Could not find feature with name "%s", skipping it', feature_id)
+                return None
+            else:
+                raise RecordNotFoundError('Could not find feature with name "%s"' % feature_id)
 
         return self._feature_cache[cache_id]['feature_id']
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('requirements.txt') as f:
 
 setup(
     name="chado",
-    version='2.3.8',
+    version='2.3.9',
     description="Chado library",
     author="Anthony Bretaudeau",
     author_email="anthony.bretaudeau@inrae.fr",


### PR DESCRIPTION
The feature IDs and names are urldecoded when loaded with the GFF, but not when loading Diamond/Interpro/etc, so the features do not match.

Example : 

The feature `BjuV_Contig00580_ERROPOS930405%2BG00020.1-P` in a diamond file and the associated GFF.
When loading the GFF file, it is stored as `BjuV_Contig00580_ERROPOS930405+G00020.1-P` in database, so they do not match when loading diamond. 


I added an urldecode when searching for the feature in cache.

(Hopefully, a blanket urldecode will not break anything..)

EDIT:

Actually try before decoding to avoid breaking stuff. (Though the gff lib seems to use the standard urllib.parse.unquote [here](https://github.com/chapmanb/bcbb/blob/dbfb52711f0bfcc1d26c5a5b53c9ff4f50dc0027/gff/BCBio/GFF/GFFParser.py#L128), so it should be fine.)
